### PR TITLE
Separate curl action from main action

### DIFF
--- a/.github/workflows/deploy-curl.yml
+++ b/.github/workflows/deploy-curl.yml
@@ -1,33 +1,17 @@
 name: "Deploy Documentation"
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  repository_dispatch:
+    types: [update_docs]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-    inputs:
-      force:
-        type: boolean
-        description: Force build (skip version check)
-        default: false
-      git_ref:
-        type: string
-        default: main
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Check out repo
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_API_TOKEN }}
-      # Node is required for npm
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
@@ -62,37 +46,37 @@ jobs:
         if: steps.evaluate_versions.outputs.versions-compare == 'false'
         run: echo "No need to update."
       - name: Checkout main repo
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         uses: actions/checkout@v3
         with:
           repository: ${{ secrets.TARGET_REPO }}
           token: ${{ secrets.GH_API_TOKEN }}
           path: main-repo
-          ref: ${{ github.event.inputs.git_ref || 'main' }}
+          ref: ${{ github.event.client_payload.git_ref || 'main' }}
       - name: Copy docs directory
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
           rm -rf ./docs
           cp -r main-repo/docs .
           rm -rf main-repo
       - name: Install deps
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
           npm install 
       - name: Create docusaurus version
-        if: (!github.event.inputs.force && steps.evaluate_versions.outputs.versions-compare == 'true')
+        if: (!github.event.client_payload.force && steps.evaluate_versions.outputs.versions-compare == 'true')
         run: |
           npx docusaurus docs:version ${{ env.REMOTE_VERSION }}
         env:
           REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
       - name: Build Docusaurus website  
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
           npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push commit
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: '[automated commit] Bump docs to version ${{ env.REMOTE_VERSION }}'
@@ -100,7 +84,7 @@ jobs:
           REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         uses: crazy-max/ghaction-github-pages@v3
         with:
           target_branch: gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,95 +16,38 @@ on:
       git_ref:
         type: string
         default: main
-
+  repository_dispatch:
+    types: [update_docs]
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Check out repo
-        uses: actions/checkout@v3
+      - name: Call deploy workflow [push_on_main]
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
         with:
-          token: ${{ secrets.GH_API_TOKEN }}
-      # Node is required for npm
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - name: Install dependencies
-        run: npm install  
-      - name: Check main repo version
-        id: check_main_repo_version
-        run: |
-          echo "::set-output name=remote-version::$(node ./scripts/check-version.js --type remote)"
-        env:
+          original_event: push_on_main
+        secrets:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_REPO: ${{ secrets.TARGET_REPO }}
-          GH_API_TOKEN: ${{ secrets.GH_API_TOKEN }}
-      - name: Check current docs version
-        id: check_current_docs_version
-        run: |
-          echo "::set-output name=docs-version::$(node ./scripts/check-version.js --type docs)"
-      - name: Print versions
-        run: |
-          echo "Remote version: ${{ env.REMOTE_VERSION }} - Docs version: ${{ env.DOCS_VERSION }}"
-        env:
-          REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
-          DOCS_VERSION: ${{ steps.check_current_docs_version.outputs.docs-version }}
-      - name: Evaluate versions
-        id: evaluate_versions
-        run: |
-          echo "::set-output name=versions-compare::$(node ./scripts/compare-versions.js --from ${{ env.DOCS_VERSION }} --to ${{ env.REMOTE_VERSION }})"
-        env:
-          REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
-          DOCS_VERSION: ${{ steps.check_current_docs_version.outputs.docs-version }}
-      - name: Nothing to do
-        if: steps.evaluate_versions.outputs.versions-compare == 'false'
-        run: echo "No need to update."
-      - name: Checkout main repo
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
-        uses: actions/checkout@v3
+      - name: Call deploy workflow [repository_dispatch]
+        if: (github.event_name == 'repository_dispatch' && github.event.action == 'update_docs')
+        uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
         with:
-          repository: ${{ secrets.TARGET_REPO }}
-          token: ${{ secrets.GH_API_TOKEN }}
-          path: main-repo
-          ref: ${{ github.event.inputs.git_ref || 'main' }}
-      - name: Copy docs directory
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
-        run: |
-          rm -rf ./docs
-          cp -r main-repo/docs .
-          rm -rf main-repo
-      - name: Install deps
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
-        run: |
-          npm install 
-      - name: Create docusaurus version
-        if: (!github.event.inputs.force && steps.evaluate_versions.outputs.versions-compare == 'true')
-        run: |
-          npx docusaurus docs:version ${{ env.REMOTE_VERSION }}
-        env:
-          REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
-      - name: Build Docusaurus website  
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
-        run: |
-          npm run build
-        env:
+          force: github.event.client_payload.force
+          git_ref: github.event.client_payload.git_ref
+          original_event: repository_dispatch
+        secrets:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push commit
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
-        uses: stefanzweifel/git-auto-commit-action@v4
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+      - name: Call deploy workflow [workflow_dispatch]
+        if: (github.event_name == 'workflow_dispatch')
+        uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
         with:
-          commit_message: '[automated commit] Bump docs to version ${{ env.REMOTE_VERSION }}'
-        env: 
-          REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
+          force: github.event.inputs.force
+          git_ref: github.event.inputs.git_ref
+          original_event: workflow_dispatch
+        secrets:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Deploy to GitHub Pages
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
-        uses: crazy-max/ghaction-github-pages@v3
-        with:
-          target_branch: gh-pages
-          build_dir: build
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+          TARGET_REPO: ${{ secrets.TARGET_REPO }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,34 +20,31 @@ on:
     types: [update_docs]
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Call deploy workflow [push_on_main]
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
-        with:
-          original_event: push_on_main
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
-      - name: Call deploy workflow [repository_dispatch]
-        if: (github.event_name == 'repository_dispatch' && github.event.action == 'update_docs')
-        uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
-        with:
-          force: github.event.client_payload.force
-          git_ref: github.event.client_payload.git_ref
-          original_event: repository_dispatch
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
-      - name: Call deploy workflow [workflow_dispatch]
-        if: (github.event_name == 'workflow_dispatch')
-        uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
-        with:
-          force: github.event.inputs.force
-          git_ref: github.event.inputs.git_ref
-          original_event: workflow_dispatch
-        secrets:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_REPO: ${{ secrets.TARGET_REPO }}
+  push-on-main:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
+    with:
+      original_event: push_on_main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
+  repository-dispatch:
+    if: (github.event_name == 'repository_dispatch' && github.event.action == 'update_docs')
+    uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
+    with:
+      force: github.event.client_payload.force
+      git_ref: github.event.client_payload.git_ref
+      original_event: repository_dispatch
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}
+  workflow-dispatch:
+    if: (github.event_name == 'workflow_dispatch')
+    uses: platformatic/oss/.github/workflows/rebuild-and-deploy-docs.yml@main
+    with:
+      force: github.event.inputs.force
+      git_ref: github.event.inputs.git_ref
+      original_event: workflow_dispatch
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TARGET_REPO: ${{ secrets.TARGET_REPO }}

--- a/.github/workflows/rebuild-and-deploy-docs.yml
+++ b/.github/workflows/rebuild-and-deploy-docs.yml
@@ -1,9 +1,16 @@
 name: "Deploy Documentation"
 
 on:
-  repository_dispatch:
-    types: [update_docs]
-
+  workflow_call:
+    inputs:
+      force:
+        type: boolean
+        default: false
+      git_ref:
+        type: string
+        default: main
+      original_event:
+        type: string
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
@@ -46,37 +53,37 @@ jobs:
         if: steps.evaluate_versions.outputs.versions-compare == 'false'
         run: echo "No need to update."
       - name: Checkout main repo
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         uses: actions/checkout@v3
         with:
           repository: ${{ secrets.TARGET_REPO }}
           token: ${{ secrets.GH_API_TOKEN }}
           path: main-repo
-          ref: ${{ github.event.client_payload.git_ref || 'main' }}
+          ref: ${{ inputs.git_ref || 'main' }}
       - name: Copy docs directory
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
           rm -rf ./docs
           cp -r main-repo/docs .
           rm -rf main-repo
       - name: Install deps
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
           npm install 
       - name: Create docusaurus version
-        if: (!github.event.client_payload.force && steps.evaluate_versions.outputs.versions-compare == 'true')
+        if: (!inputs.force && steps.evaluate_versions.outputs.versions-compare == 'true')
         run: |
           npx docusaurus docs:version ${{ env.REMOTE_VERSION }}
         env:
           REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
       - name: Build Docusaurus website  
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         run: |
           npm run build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push commit
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: '[automated commit] Bump docs to version ${{ env.REMOTE_VERSION }}'
@@ -84,7 +91,7 @@ jobs:
           REMOTE_VERSION: ${{ steps.check_main_repo_version.outputs.remote-version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to GitHub Pages
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.force || steps.evaluate_versions.outputs.versions-compare == 'true'
+        if: inputs.original_event == 'push_on_main' || inputs.force || steps.evaluate_versions.outputs.versions-compare == 'true'
         uses: crazy-max/ghaction-github-pages@v3
         with:
           target_branch: gh-pages


### PR DESCRIPTION
Lately the deploy action triggered by `curl` returned a 422 error.

The payload sent was 
```
{"event_type": "update_docs", "inputs": { "git_ref": "main", "force": true }}
```
And the error says
```
{
  "message": "Invalid request.\n\n\"inputs\" is not a permitted key.",
  "documentation_url": "https://docs.github.com/rest/reference/repos#create-a-repository-dispatch-event"
}
```

I have created a new workflow file that would accept a `client_payload` property from the event. This should land in `main` before it can be tested