### PR TITLE
Create a deployment category under Guides

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -35,7 +35,19 @@ const sidebars = {
       },
       collapsed: true,
       items: [
-        'guides/deployment/deployment',
+        {
+          type: 'category',
+          label: 'Deployment',
+          link: {
+            type: 'doc',
+            id: 'guides/deployment/deployment'
+          },
+          collapsed: true,
+          items: [
+            'guides/deployment/deploy-to-fly-io-with-sqlite',
+            'guides/deployment/advanced-fly-io-deployment'
+          ]
+        },
         'guides/seed-a-database',
         {
           type: 'category',


### PR DESCRIPTION
This updates the sidebar to have a deployments category. It will require the files in https://github.com/platformatic/platformatic/pull/61 to be merged before the index will render correctly.

Here is what it will look like:
![deployment-category](https://user-images.githubusercontent.com/108896003/199400403-ef5040c3-e1a2-4d2f-8549-ec90f0c718b6.png)

This seems to show up under the `next` version though the linked guides were written for `0.4.0`. I am unsure if this change will be automatically added to `0.4.0` sidebar or if I need to make further changes.