### PR TITLE
Add Platformatic Service reference docs category

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -105,7 +105,19 @@ const sidebars = {
             'reference/db/dashboard'
           ]
         },
-
+        {
+          type: 'category',
+          label: 'Platformatic Service',
+          link: {
+            type: 'doc',
+            id: 'reference/service/introduction'
+          },
+          collapsed: false,
+          items: [
+            'reference/service/configuration',
+            'reference/service/plugin',
+          ]
+        },
         {
           type: 'category',
           label: 'Packages',


### PR DESCRIPTION
This adds a 'Platformatic Service' reference docs category in the Docusaurus sidebar.