### PR TITLE
Add SQL-Events reference docs category

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -168,7 +168,19 @@ const sidebars = {
                   ]
                 }
               ]
-            }
+            },
+            {
+              type: 'category',
+              label: 'SQL-Events',
+              link: {
+                type: 'doc',
+                id: 'reference/sql-events/introduction'
+              },
+              collapsed: true,
+              items: [
+                'reference/sql-events/fastify-plugin'
+              ]
+            },
           ]
         }
       ]


### PR DESCRIPTION
This adds an 'SQL-Events' reference docs category in the Docusaurus sidebar.