### PR TITLE
Fix documentation for logger

### DIFF
--- a/versioned_docs/version-0.6.1/reference/db/configuration.md
+++ b/versioned_docs/version-0.6.1/reference/db/configuration.md
@@ -393,12 +393,12 @@ and must meet the [allowed placeholder name](#allowed-placeholder-names) rules.
 ```json title="platformatic.db.json"
 {
   "core": {
-    "logger": {
-      "level": "{PLT_SERVER_LOGGER_LEVEL}"
-    },
     "connectionString": "{DATABASE_URL}"
   },
   "server": {
+    "logger": {
+      "level": "{PLT_SERVER_LOGGER_LEVEL}"
+    },
     "port": "{PORT}"
   }
 }


### PR DESCRIPTION
As mentioned on [this issue](https://github.com/platformatic/platformatic/issues/305), the current documentation for the logger config is not correct.

From [here](https://github.com/platformatic/platformatic/blob/6da734ffc741a0313bf71298c4fd02f36e182767/packages/service/lib/utils.js#L27), we see that is under the `server` prop, not the `core` one.

This PR simply updates the documentation 😊 