### PR TITLE
Rename SQL-to-REST to SQL-to-OpenAPI

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -129,14 +129,14 @@ const sidebars = {
           items: [
             {
               type: 'category',
-              label: 'SQL-to-REST',
+              label: 'SQL-to-OpenAPI',
               link: {
                 type: 'doc',
-                id: 'reference/sql-rest/introduction'
+                id: 'reference/sql-openapi/introduction'
               },
               collapsed: true,
               items: [
-                'reference/sql-rest/api'
+                'reference/sql-openapi/api'
               ]
             },
             {


### PR DESCRIPTION
These changes correspond with the renaming changes made in pull request https://github.com/platformatic/platformatic/pull/342.
