### PR TITLE
Add missing documentation to sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -137,7 +137,8 @@ const sidebars = {
               },
               collapsed: true,
               items: [
-                'reference/sql-openapi/api'
+                'reference/sql-openapi/api',
+                'reference/sql-openapi/ignore'
               ]
             },
             {
@@ -150,7 +151,9 @@ const sidebars = {
               collapsed: true,
               items: [
                 'reference/sql-graphql/queries',
-                'reference/sql-graphql/mutations'
+                'reference/sql-graphql/mutations',
+                'reference/sql-graphql/many-to-many',
+                'reference/sql-graphql/ignore'
               ]
             },
             {


### PR DESCRIPTION
Adds sidebar links for docs adding in the following PRs:

- https://github.com/platformatic/platformatic/pull/386
- https://github.com/platformatic/platformatic/pull/389

Signed-off-by: Simon Plenderleith <simon@simonplend.co.uk>
