### PR TITLE
Adds minimum supported versions for databases

### DIFF
--- a/versioned_docs/version-0.15.1/reference/db/introduction.md
+++ b/versioned_docs/version-0.15.1/reference/db/introduction.md
@@ -42,10 +42,10 @@ Get up and running in 2 minutes using our
 
 ## Supported databases
 
-- [SQLite](https://www.sqlite.org/)
-- [PostgreSQL](https://www.postgresql.org/)
-- [MySQL](https://www.mysql.com/)
-- [MariaDB](https://mariadb.org/)
+- [SQLite](https://www.sqlite.org/) >= 5.1.4
+- [PostgreSQL](https://www.postgresql.org/) >= 15-alpine
+- [MySQL](https://www.mysql.com/) >= 5.7
+- [MariaDB](https://mariadb.org/) >= 10.11
 
 The required database driver is automatically inferred and loaded based on the
 value of the [`connectionString`](/reference/db/configuration.md#core)


### PR DESCRIPTION
This is related to [Minimum supported database versions #693](https://github.com/platformatic/platformatic/issues/693) on the platformatic repo. I retrieved the minimum required versions from the docker-compose file and from the GitHub actions.