### PR TITLE
Add Prisma guide to the sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -66,7 +66,8 @@ const sidebars = {
         'guides/securing-platformatic-db',
         'guides/jwt-auth0',
         'guides/monitoring',
-        'guides/debug-platformatic-db'
+        'guides/debug-platformatic-db',
+        'guides/prisma',
       ]
     },
 


### PR DESCRIPTION
Adds the 'Integrate Prisma with Platformatic DB' guide under the
'Guides' category in the sidebar.
