### PR TITLE
Add groovy as a language for Prism to syntax highlight

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -140,6 +140,7 @@ const config = {
       prism: {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
+        additionalLanguages: ['groovy'],
       },
     }),
 };


### PR DESCRIPTION
You'll be able to see it in action on https://oss.platformatic.dev/docs/next/guides/prisma/ for the `schema.prisma` blocks.

![image](https://user-images.githubusercontent.com/2773428/221237426-3b656191-49d8-4ac7-b1c4-3fb1ee09318d.png)
