### PR TITLE
Enable 'Edit this page' links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,6 +33,7 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          editUrl: 'https://github.com/platformatic/platformatic/edit/main/',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
Every page on the rendered site now shows an 'Edit this page' link at the bottom. It points to the edit URL on GitHub for the source Markdown document.

See: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#editUrl

Signed-off-by: Simon Plenderleith <simon@simonplend.co.uk>
