### PR TITLE
Add guide to sidebar: Migrating a Fastify app to Platformatic Service

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -68,6 +68,7 @@ const sidebars = {
         'guides/monitoring',
         'guides/debug-platformatic-db',
         'guides/prisma',
+        'guides/migrating-fastify-app-to-platformatic-service'
       ]
     },
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -86,3 +86,9 @@ main a {
     height: auto;
   }
 }
+
+.aspect-ratio-16-9 {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16/9;
+}


### PR DESCRIPTION
Adds the 'Migrating a Fastify app to Platformatic Service' guide to the sidebar.

This also adds CSS that allows content to be scaled responsively with a 16:9 aspect ratio. In this guide, that allows the embedded video to be displayed correctly on different screen sizes.

Companion PR: https://github.com/platformatic/platformatic/pull/1057