### PR TITLE
fix: edit link for versioned docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -33,7 +33,12 @@ const config = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/platformatic/platformatic/edit/main/',
+          editUrl: ({ docPath, version, versionDocsDirPath }) => {
+            if (version === 'current') {
+              return `https://github.com/platformatic/platformatic/edit/main/docs/${docPath}`;
+            }
+            return `https://github.com/platformatic/oss/edit/main/${versionDocsDirPath}/${docPath}`;
+          }
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
This fixes the "Edit" link at the bottom of the versioned docs.

The edit links for the "Next" version will link to the https://github.com/platformatic/platformatic repo. All versioned edit links will link to the https://github.com/platformatic/oss repo.

Fixes #73 